### PR TITLE
Use elixir 1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir
+FROM elixir:1.9
 
 LABEL "repository"="https://github.com/jclem/action-mix"
 LABEL "homepage"="https://github.com/jclem/action-mix"

--- a/deps.get/Dockerfile
+++ b/deps.get/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir
+FROM elixir:1.9
 
 LABEL "repository"="https://github.com/jclem/action-mix"
 LABEL "homepage"="https://github.com/jclem/action-mix"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir
+FROM elixir:1.9
 
 LABEL "repository"="https://github.com/jclem/action-mix"
 LABEL "homepage"="https://github.com/jclem/action-mix"


### PR DESCRIPTION
@jclem Hey mate, I had to fix this to be able to use the action with Elixir 1.9 which is the latest version since I am using `Config` instead of `Mix.Config`.

I will recommend keeping this version instead of relying on whatever Docker register decides that is the default one.