### PR TITLE
Sets the Elixir image version explicitly to 1.9.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir
+FROM elixir:1.9.1
 
 LABEL "repository"="https://github.com/jclem/action-mix"
 LABEL "homepage"="https://github.com/jclem/action-mix"

--- a/deps.get/Dockerfile
+++ b/deps.get/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir
+FROM elixir:1.9.1
 
 LABEL "repository"="https://github.com/jclem/action-mix"
 LABEL "homepage"="https://github.com/jclem/action-mix"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir
+FROM elixir:1.9.1
 
 LABEL "repository"="https://github.com/jclem/action-mix"
 LABEL "homepage"="https://github.com/jclem/action-mix"


### PR DESCRIPTION
Sets the Elixir image version explicitly to 1.9.1 to ensure predictable results. This is mostly relevant because of linting / formatting rules changing between Elixir versions in a way that can create mysterious failures without code changes.